### PR TITLE
Refactor ast2sql.ml by introducing intermediate representations for SQL queries

### DIFF
--- a/src/utils.ml
+++ b/src/utils.ml
@@ -336,7 +336,7 @@ let build_eqtab eqs =
   hs
 
 (** Given a var name, returns the value and removes it from the eqtab. *)
-let eqt_extract eqt e1 =
+let eqt_extract (eqt : eqtab) (e1 : vterm) : vterm =
   let lst = Hashtbl.find_all eqt e1 in
   if ((List.length lst) <> 1) then raise (SemErr ("Ambiguity of the assigments of variable "^(string_of_vterm e1)));
   let c = List.hd lst in

--- a/src/utils.ml
+++ b/src/utils.ml
@@ -42,7 +42,7 @@ let spec_lex_error lexbuf =
     are rule-name & rule-arity tuples and the values are lists of
     rules' AST specifications.
 *)
-type symtkey = (string*int) (* string is predicate name, int is the arity of literal*)
+type symtkey = string * int (* string is predicate name, int is the arity of literal*)
 type symtable = (symtkey, (rterm * term list) list) Hashtbl.t (* each row of a symtable is all the rules which has the same literal in head*)
 
 (* let hash_max_size = ref 500 *)


### PR DESCRIPTION
This PR refactors `ast2sql.ml` by introducing intermediate representations that stand for SQL queries.

The operation check has been performed by the following step:

1. Run `benchmarks/benchmark.sh`.
2. Compare the resulting log files `benchmarks/results/compile/*/*.{log,err}` to the equivalent ones produced by `master`’s `birds`.

Through this check, it has been confirmed that the produced log files were exactly the same as `master`’s ones (though produced SQL files have some diffs as to spaces, breaks, and parentheses; see `ced.diff` in the following Gist (i.e. the diff of the two `benchmarks/results/gensql/case-study/ced.sql`s) for example: [link](https://gist.github.com/gfngfn/4652fa0589742b17993b09d9e06cfcd1)).

I would appreciate it if you could take a look at this PR and/or give any comment or suggestion.