### PR TITLE
Introduce IR for representing Lean terms

### DIFF
--- a/src/ast2fol.ml
+++ b/src/ast2fol.ml
@@ -18,6 +18,11 @@ open Rule_preprocess
 open Stratification
 open Derivation
 
+
+let lean_string_of_fol_formula (fm : fol formula) : string =
+  stringify_lean_formula (lean_formula_of_fol_formula fm)
+
+
 (** convert vterm into Fol.term *)
 let rec folterm_of_vterm ae =
     match ae with

--- a/src/ast2theorem.ml
+++ b/src/ast2theorem.ml
@@ -316,7 +316,7 @@ let stringify_lean_type (ltyp : lean_type) : string =
   let rec aux (ltyp : lean_type) : string =
     match ltyp with
     | LeanBaseType styp           -> stype_to_lean_type styp
-    | LeanFuncType (ltyp1, ltyp2) -> Printf.sprintf "(%s -> %s)" (aux ltyp1) (aux ltyp2)
+    | LeanFuncType (ltyp1, ltyp2) -> Printf.sprintf "(%s → %s)" (aux ltyp1) (aux ltyp2)
   in
   aux ltyp
 

--- a/src/ast2theorem.ml
+++ b/src/ast2theorem.ml
@@ -125,9 +125,6 @@ let source_to_lean_func_types (prog : expr) : (string * lean_type) list =
       List.fold_right (fun (_col, styp) ltyp -> LeanFuncType (LeanBaseType styp, ltyp)) lst (LeanBaseType Sbool)
     in
     (name, ltyp) :: funcs
-(* ORIGINAL:
-    (name ^ ": " ^ String.concat " → " (List.map (fun (col, typ) -> stype_to_lean_type typ) lst) ^ " → Prop") :: funcs
-*)
   in
   List.fold_left p_el [] prog.sources
 
@@ -146,9 +143,6 @@ let source_view_to_lean_func_types (prog : expr) : (string * lean_type) list =
       List.fold_right (fun (_col, styp) ltyp -> LeanFuncType (LeanBaseType styp, ltyp)) lst (LeanBaseType Sbool)
     in
     (name, ltyp) :: funcs
-(* ORIGINAL:
-    (name ^ ": " ^ String.concat " → " ( List.map (fun (col, typ) -> stype_to_lean_type typ) lst) ^ " → Prop" ) :: funcs
-*)
   in
   List.fold_left p_el [] (get_schema_stts prog)
 
@@ -207,13 +201,6 @@ let lean_simp_theorem_of_disjoint_delta (debug : bool) (prog : expr) : lean_theo
     parameter = source_view_to_lean_func_types prog;
     statement = statement;
   }
-(* ORIGINAL:
-  "theorem disjoint_deltas "
-    ^ String.concat " " (List.map (fun x -> "{" ^ x ^"}") (source_view_to_lean_func_types prog)) ^ ": "
-    ^ (Fol_ex.lean_string_of_fol_formula
-        (Imp (Ast2fol.constraint_sentence_of_stt debug prog,
-          (Imp (Ast2fol.disjoint_delta_sentence_of_stt debug prog, False)))))
-*)
 
 let lean_simp_theorem_of_getput (debug : bool) (prog : expr) : lean_theorem =
   if debug then print_endline "==> generating theorem of getput property" else ();
@@ -227,12 +214,6 @@ let lean_simp_theorem_of_getput (debug : bool) (prog : expr) : lean_theorem =
     parameter = source_to_lean_func_types prog;
     statement = statement;
   }
-(* ORIGINAL:
-  "theorem getput " ^ String.concat " " (List.map (fun x -> "{"^x^"}") (source_to_lean_func_types prog)) ^ ": "
-    ^ (Fol_ex.lean_string_of_fol_formula
-         (Imp (Ast2fol.non_view_constraint_sentence_of_stt debug prog,
-           (Imp (Ast2fol.getput_sentence_of_stt debug prog, False)))))
-*)
 
 let lean_simp_theorem_of_putget (debug : bool) (prog : expr) : lean_theorem =
   if debug then print_endline "==> generating theorem of putget property" else ();
@@ -245,12 +226,6 @@ let lean_simp_theorem_of_putget (debug : bool) (prog : expr) : lean_theorem =
     parameter = source_view_to_lean_func_types prog;
     statement = statement;
   }
-(* ORIGINAL:
-  "theorem putget "
-    ^ String.concat " " (List.map (fun x -> "{" ^ x ^ "}") (source_view_to_lean_func_types prog)) ^ ": "
-    ^ (Fol_ex.lean_string_of_fol_formula
-        (Imp (Ast2fol.constraint_sentence_of_stt debug prog, Ast2fol.putget_sentence_of_stt debug prog)))
-*)
 
 (* take a view update datalog program and generate the theorem of checking whether all delta relations are disjoint *)
 let z3_assert_of_disjoint_delta (debug:bool) prog =
@@ -303,11 +278,6 @@ let lean_simp_sourcestability_theorem_of_stt (debug : bool) (prog : expr) : lean
     parameter = source_to_lean_func_types prog;
     statement = statement;
   }
-(* ORIGINAL:
-  "theorem sourcestability "
-    ^ String.concat " " (List.map (fun x -> "{" ^ x ^ "}") (source_to_lean_func_types prog)) ^ ": "
-    ^ (Fol_ex.lean_string_of_fol_formula (Imp (Ast2fol.sourcestability_sentence_of_stt debug prog, False)))
-*)
 
 let make_lean_theorem (name : string) (parameter : (string * lean_type) list) (statement : Fol_ex.lean_formula) : lean_theorem =
   LeanTheorem { name; parameter; statement }

--- a/src/ast2theorem.mli
+++ b/src/ast2theorem.mli
@@ -1,12 +1,18 @@
 
-val source_to_lean_func_types : Expr.expr -> string list
+type lean_type
 
-val lean_simp_theorem_of_disjoint_delta : bool -> Expr.expr -> string
+type lean_theorem
 
-val lean_simp_theorem_of_getput : bool -> Expr.expr -> string
+val source_to_lean_func_types : Expr.expr -> (string * lean_type) list
 
-val lean_simp_theorem_of_putget : bool -> Expr.expr -> string
+val lean_simp_theorem_of_disjoint_delta : bool -> Expr.expr -> lean_theorem
 
-val gen_lean_code_for_theorems : string list -> string
+val lean_simp_theorem_of_getput : bool -> Expr.expr -> lean_theorem
+
+val lean_simp_theorem_of_putget : bool -> Expr.expr -> lean_theorem
+
+val make_lean_theorem : string -> (string * lean_type) list -> Fol_ex.lean_formula -> lean_theorem
+
+val gen_lean_code_for_theorems : lean_theorem list -> string
 
 val validity_lean_code_of_bidirectional_datalog : bool -> Expr.expr -> string

--- a/src/bx.ml
+++ b/src/bx.ml
@@ -71,11 +71,6 @@ let lean_simp_theorem_of_view_uniqueness (log : bool) (prog : Expr.expr) : lean_
       (Fol_ex.lean_formula_of_fol_formula
         (Imp (Ast2fol.constraint_sentence_of_stt log prog,
           view_uniqueness_sentence_of_stt log prog)))
-(* ORIGINAL:
-    "theorem view_uniqueness " ^ String.concat " " (List.map (fun x -> "{"^x^"}") (source_to_lean_func_types prog)) ^
-     ": " ^ (Fol_ex.lean_string_of_fol_formula (Imp (Ast2fol.constraint_sentence_of_stt log prog,
-     view_uniqueness_sentence_of_stt log prog)))
-*)
 
 (* Take a view update put datalog program and derive the corresponding get datalog. *)
 let derive_get_datalog (log:bool) (speedup:bool) timeout inputprog =
@@ -145,11 +140,6 @@ let derive_get_datalog (log:bool) (speedup:bool) timeout inputprog =
         (Fol_ex.lean_formula_of_fol_formula
           (Imp (non_view_constraint_sentence_of_stt log prog,
             And (sentence_of_view_existence, generalize (Imp (phi, False))))))
-(* ORIGINAL:
-      "theorem view_existence " ^ String.concat " " (List.map (fun x -> "{"^x^"}") (source_to_lean_func_types prog)) ^
-     ": " ^ (Fol_ex.lean_string_of_fol_formula (Imp (non_view_constraint_sentence_of_stt log prog,
-     And(sentence_of_view_existence, generalize (Imp (phi, False))))))
-*)
     in
     let lean_code_view_existence = gen_lean_code_for_theorems [theorem_of_view_existence] in
 

--- a/src/logic/fol_ex.ml
+++ b/src/logic/fol_ex.ml
@@ -1,41 +1,44 @@
 (*******************************************************)
-(**  
+(**
 Functions on first-order logic formulas
  *)
 (********************************************************)
 
-(* 
+(*
 author: Vandang Tran
 *)
 
-open Lib;;
-open Formulas;;
-open Fol;;
-open Skolem;;
-open Prop;;
+open Lib
+open Formulas
+open Fol
+open Skolem
+open Prop
 
 (* ------------------------------------------------------------------------- *)
 (* Printing of formulas, parametrized by atom printer.                       *)
 (* ------------------------------------------------------------------------- *)
 
-let rec normalize_comparison fm =
+let rec normalize_comparison (fm : fol formula) : fol formula =
   match fm with
-  Atom(R(r,args)) -> (match r with 
-    | "<>" -> Not(Atom(R("=",args)))
-    | "<=" -> Not(Atom(R(">",args)))
-    | ">=" -> Not(Atom(R("<",args)))
-    | _ -> fm
-    )
-  | Not p ->  (Not(normalize_comparison p))
-  | And(p,q) ->  (And(normalize_comparison p,normalize_comparison q))
-  | Or(p,q) ->  (Or(normalize_comparison p,normalize_comparison q))
-  | Imp(p,q) ->  (Imp(normalize_comparison p,normalize_comparison q))
-  | Iff(p,q) ->  (Iff(normalize_comparison p,normalize_comparison q))
-  | Forall(x,p) -> (Forall(x,normalize_comparison p))
-  | Exists(x,p) -> (Exists(x,normalize_comparison p))
-  | _ -> fm;;
+  | Atom (R (r, args)) ->
+      begin
+        match r with
+        | "<>" -> Not (Atom (R ("=", args)))
+        | "<=" -> Not (Atom (R (">", args)))
+        | ">=" -> Not (Atom (R ("<", args)))
+        | _    -> fm
+      end
 
-let normal_logic_character name = match name with 
+  | Not p        -> Not (normalize_comparison p)
+  | And(p, q)    -> And (normalize_comparison p, normalize_comparison q)
+  | Or(p, q)     -> Or (normalize_comparison p, normalize_comparison q)
+  | Imp(p, q)    -> Imp (normalize_comparison p, normalize_comparison q)
+  | Iff(p, q)    -> Iff (normalize_comparison p, normalize_comparison q)
+  | Forall(x, p) -> Forall (x, normalize_comparison p)
+  | Exists(x, p) -> Exists (x, normalize_comparison p)
+  | _            -> fm
+
+let normal_logic_character name = match name with
     | "false" -> "false"
     | "true" -> "true"
     | "not" -> "~"
@@ -127,7 +130,106 @@ let string_of_fol_formula = string_of_qformula string_of_atom;;
 (* Printing of formulas in lean.                                             *)
 (* ------------------------------------------------------------------------- *)
 
-let lean_logic_character name = match name with 
+type lean_variable = string
+
+type lean_infix_operator =
+  | LeanInfixEqual    (* = *)
+  | LeanInfixLt       (* < *)
+  | LeanInfixGt       (* > *)
+  | LeanInfixNotEqual (* ≠ *)
+  | LeanInfixLeq      (* ≤ *)
+  | LeanInfixGeq      (* ≥ *)
+  | LeanInfixAnd      (* ∧ *)
+  | LeanInfixOr       (* ∨ *)
+  | LeanInfixImp      (* → *)
+  | LeanInfixIff      (* ↔ *)
+  | LeanInfixConcat   (* ++ *)
+  | LeanInfixDiv      (* / *)
+  | LeanInfixMult     (* * *)
+  | LeanInfixSubtr    (* - *)
+  | LeanInfixAdd      (* + *)
+  | LeanInfixCons     (* :: *)
+
+(* isomorphic to `Expr.stype` *)
+type lean_annot =
+  | LeanAnnotInt
+  | LeanAnnotRat
+  | LeanAnnotString
+  | LeanAnnotProp
+
+type lean_formula =
+  | LeanNull
+  | LeanBool   of bool
+  | LeanInt    of int
+  | LeanFloat  of float
+  | LeanString of string
+  | LeanVar    of lean_variable
+  | LeanNot    of lean_formula
+  | LeanInfix  of lean_infix_operator * lean_formula * lean_formula
+  | LeanApp    of string * lean_formula list
+  | LeanForall of lean_variable * lean_formula
+  | LeanExists of lean_variable * lean_formula
+  | LeanAnnot  of lean_formula * lean_annot
+
+
+let stringify_lean_infix_operator = function
+  | LeanInfixEqual    -> "="
+  | LeanInfixLt       -> "<"
+  | LeanInfixGt       -> ">"
+  | LeanInfixNotEqual -> "≠"
+  | LeanInfixLeq      -> "≤"
+  | LeanInfixGeq      -> "≥"
+  | LeanInfixAnd      -> "∧"
+  | LeanInfixOr       -> "∨"
+  | LeanInfixImp      -> "→"
+  | LeanInfixIff      -> "↔"
+  | LeanInfixConcat   -> "++"
+  | LeanInfixDiv      -> "/"
+  | LeanInfixMult     -> "*"
+  | LeanInfixSubtr    -> "-"
+  | LeanInfixAdd      -> "+"
+  | LeanInfixCons     -> "::"
+
+
+let stringify_lean_formula (lfm : lean_formula) : string =
+  let rec aux (lfm : lean_formula) =
+    match lfm with
+    | LeanNull       -> "null"
+    | LeanBool true  -> "true"
+    | LeanBool false -> "false"
+    | LeanInt n      -> string_of_int n
+    | LeanFloat r    -> string_of_float r
+    | LeanString s   -> Printf.sprintf "\"%s\"" s
+    | LeanVar x      -> x
+    | LeanNot lfm0   -> Printf.sprintf "(¬ %s)" (aux lfm0)
+
+    | LeanInfix (op, lfm1, lfm2) ->
+        let s_op = stringify_lean_infix_operator op in
+        let s1 = aux lfm1 in
+        let s2 = aux lfm2 in
+        Printf.sprintf "(%s %s %s)" s1 s_op s2
+
+    | LeanApp (f, lfms) ->
+        let ss = lfms |> List.map aux in
+        Printf.sprintf "(%s %s)" f (String.concat " " ss)
+
+    | LeanForall (x, lfm0) -> Printf.sprintf "(∀%s, %s)" x (aux lfm0)
+    | LeanExists (x, lfm0) -> Printf.sprintf "(∃%s, %s)" x (aux lfm0)
+
+    | LeanAnnot (lfm0, styp) ->
+        let annot =
+          match styp with
+          | LeanAnnotInt    -> "int"
+          | LeanAnnotRat    -> "rat"
+          | LeanAnnotProp   -> "Prop"
+          | LeanAnnotString -> "string"
+        in
+        Printf.sprintf "(%s: %s)" (aux lfm0) annot
+  in
+  aux lfm
+
+(*
+let lean_logic_character name = match name with
     | "false" -> "false"
     | "true" -> "true"
     | "not" -> "¬"
@@ -140,36 +242,69 @@ let lean_logic_character name = match name with
     | "quantifer_sep" -> ","
     | _ -> failwith "unkown symbol of "^name
 
-let lean_character_of_operator o = match o with 
+let lean_character_of_operator o = match o with
   | "<>" -> "≠"
   | ">=" -> "≥"
   | "<=" -> "≤"
   | "=" | "<"| ">" -> o
   | _ -> failwith "unkown symbol of "^o
 
-let lean_stype_of_string str = 
+let lean_stype_of_string (str : string) =
   try  (ignore(int_of_string str); "int") with
     (* try test () with *)
-    | Failure e -> 
+    | Failure e ->
         try  (ignore(float_of_string str); "rat") with
         (* try test () with *)
-        | Failure e -> 
+        | Failure e ->
             try  ( ignore(bool_of_string str); "Prop") with
             | Failure e | Invalid_argument e ->  if (str = "null") then  "int" else  "string"
 
-let lean_string_of_string str = 
+let lean_string_of_string (str : string) =
   try  (ignore(int_of_string str); str) with
     (* try test () with *)
-    | Failure e -> 
+    | Failure e ->
         try  (ignore(float_of_string str); str) with
         (* try test () with *)
-        | Failure e -> 
+        | Failure e ->
             try  ( ignore(bool_of_string str); str) with
-            | Failure e | Invalid_argument e ->  
+            | Failure e | Invalid_argument e ->
             if (str = "null") then  str else "\""^(String.sub str 1 (String.length str -2))^"\""
+*)
+
+let lean_formula_of_literal (str : string) : lean_formula * lean_annot =
+  try
+    let n = int_of_string str in
+    (LeanInt n, LeanAnnotInt)
+  with
+  | _ ->
+      try
+        let r = float_of_string str in
+        (LeanFloat r, LeanAnnotRat)
+      with
+      | _ ->
+          try
+            let b = bool_of_string str in
+            (LeanBool b, LeanAnnotProp)
+          with
+          | _ ->
+              match str with
+              | "null" -> (LeanNull, LeanAnnotInt)
+              | _      -> (LeanString (String.sub str 1 (String.length str - 2)), LeanAnnotString)
 
 
-let rec lean_string_of_term prec fm =
+let rec lean_formula_of_term (fm : term) : lean_formula =
+  let iter = lean_formula_of_term in
+  match fm with
+  | Var x                      -> LeanVar x
+  | Fn ("^", [tm1; tm2])       -> LeanInfix (LeanInfixConcat, iter tm1, iter tm2)
+  | Fn ("/", [tm1; tm2])       -> LeanInfix (LeanInfixDiv, iter tm1, iter tm2)
+  | Fn ("*", [tm1; tm2])       -> LeanInfix (LeanInfixMult, iter tm1, iter tm2)
+  | Fn ("-", [tm1; tm2])       -> LeanInfix (LeanInfixSubtr, iter tm1, iter tm2)
+  | Fn ("+", [tm1; tm2])       -> LeanInfix (LeanInfixAdd, iter tm1, iter tm2)
+  | Fn ("::", [tm1; tm2])      -> LeanInfix (LeanInfixCons, iter tm1, iter tm2)
+  | Fn (literal, [])           -> let (lfm, styp) = lean_formula_of_literal literal in LeanAnnot (lfm, styp)
+  | Fn (f, ((_ :: _) as args)) -> LeanApp (f, List.map iter args)
+(* ORIGINAL:
   match fm with
     Var x -> x
   | Fn("^",[tm1;tm2]) -> lean_string_of_infix_term true prec 24 "++" tm1 tm2
@@ -179,9 +314,13 @@ let rec lean_string_of_term prec fm =
   | Fn("+",[tm1;tm2]) -> lean_string_of_infix_term false prec 16 " +" tm1 tm2
   | Fn("::",[tm1;tm2]) -> lean_string_of_infix_term false prec 14 "::" tm1 tm2
   | Fn(f,args) -> lean_string_of_fargs f args
+*)
 
-and lean_string_of_fargs f args =
-    if args = [] then "("^(lean_string_of_string f)^":"^ (lean_stype_of_string f)^")" else
+(*
+and lean_string_of_fargs (f : string) (args : term list) : lean_formula =
+  if args = [] then
+    "("^(lean_string_of_string f)^":"^ (lean_stype_of_string f)^")"
+  else
     f^ ( "("^
     lean_string_of_term 0 (hd args)^ break_line 0^
     String.concat "" (List.map (fun t ->  ","^break_line 0^ lean_string_of_term 0 t)
@@ -203,37 +342,63 @@ let lean_string_of_fargs f args =
     lean_string_of_term 0 (hd args)^ break_line 0^
     String.concat "" (List.map (fun t ->  " "^break_line 0^ lean_string_of_term 0 t)
             (tl args)))
+*)
 
-let rec lean_string_of_atom prec (R(p,args)) =
-  if mem p ["="; "<"; "<="; ">"; ">="; "<>"] && length args = 2
-  then lean_string_of_infix_term false 12 12 (" "^ lean_character_of_operator p) (el 0 args) (el 1 args)
-  else lean_string_of_fargs p args;;
+let lean_formula_of_atom (R (p, args) : fol) : lean_formula =
+  let iter = lean_formula_of_term in
+  match (p, args) with
+  | ("=", [tm1; tm2])  -> LeanInfix (LeanInfixEqual, iter tm1, iter tm2)
+  | ("<", [tm1; tm2])  -> LeanInfix (LeanInfixLt, iter tm1, iter tm2)
+  | (">", [tm1; tm2])  -> LeanInfix (LeanInfixGt, iter tm1, iter tm2)
+  | ("<>", [tm1; tm2]) -> LeanInfix (LeanInfixNotEqual, iter tm1, iter tm2)
+  | ("<=", [tm1; tm2]) -> LeanInfix (LeanInfixLeq, iter tm1, iter tm2)
+  | (">=", [tm1; tm2]) -> LeanInfix (LeanInfixGeq, iter tm1, iter tm2)
+  | _                  -> LeanApp (p, List.map iter args)
 
-let lean_string_of_qformula pfn fm =
-    string_of_formula lean_logic_character pfn (normalize_comparison fm);;
+(* ORIGINAL:
+  if mem p ["="; "<"; "<="; ">"; ">="; "<>"] && length args = 2 then
+    lean_string_of_infix_term false 12 12 (" "^ lean_character_of_operator p) (el 0 args) (el 1 args)
+  else
+    lean_string_of_fargs p args
+*)
 
-let lean_string_of_fol_formula = lean_string_of_qformula lean_string_of_atom;;
+
+let lean_formula_of_fol_formula (fm : fol formula) : lean_formula =
+  let rec aux fm =
+    match fm with
+    | False        -> LeanBool false
+    | True         -> LeanBool true
+    | Atom pargs   -> lean_formula_of_atom pargs
+    | Not p        -> LeanNot (aux p)
+    | And (p, q)   -> LeanInfix (LeanInfixAnd, aux p, aux q)
+    | Or (p, q)    -> LeanInfix (LeanInfixOr, aux p, aux q)
+    | Imp(p, q)    -> LeanInfix (LeanInfixImp, aux p, aux q)
+    | Iff(p, q)    -> LeanInfix (LeanInfixIff, aux p, aux q)
+    | Forall(x, p) -> LeanForall (x, aux p)
+    | Exists(x, p) -> LeanExists (x, aux p)
+  in
+  aux (normalize_comparison fm)
 
 (* ------------------------------------------------------------------------- *)
 (* Printing of formulas in z3.                                             *)
 (* ------------------------------------------------------------------------- *)
 
-(** get a type of a free variable in the formula 
+(** get a type of a free variable in the formula
 (not completed yet) *)
-let rec type_of_var varname fm = 
+let rec type_of_var varname fm =
   match fm with
     False -> []
   | True -> []
-  | Atom(R(r,args)) -> 
+  | Atom(R(r,args)) ->
     if r = "=" then (
-      let v, o = List.partition (fun x -> x = varname) (List.map (string_of_term 0) args) in 
+      let v, o = List.partition (fun x -> x = varname) (List.map (string_of_term 0) args) in
       [(r^ hd o, 0)]
     )
     else
     (let lst,_ = List.fold_left
       (fun (lst, index) str -> if (string_of_term 0 str) = varname then (lst@[index], index+1) else (lst, index+1))
       ([],0)
-      args in 
+      args in
     List.map (fun x -> (r,x)) lst)
   | Not(p) -> type_of_var varname p
   | And(p,q) -> union (type_of_var varname p)  (type_of_var varname q)
@@ -243,7 +408,7 @@ let rec type_of_var varname fm =
   | Forall(x,p) -> type_of_var varname (let newx = variant x (varname::(fv fm)) in subst (x |=> Var newx) p)
   | Exists(x,p) -> type_of_var varname (let newx = variant x (varname::(fv fm)) in subst (x |=> Var newx) p)
 
-let z3_logic_character name = match name with 
+let z3_logic_character name = match name with
     | "false" -> "false"
     | "true" -> "true"
     | "not" -> "not"
@@ -256,25 +421,25 @@ let z3_logic_character name = match name with
     | "quantifer_sep" -> failwith "unkown symbol of "^name
     | _ -> failwith "unkown symbol of "^name
 
-let z3_character_of_operator o = match o with 
+let z3_character_of_operator o = match o with
   | "<>" -> failwith "unkown symbol of "^o
   | ">="
   | "<="
   | "=" | "<"| ">" -> o
   | _ -> failwith "unkown symbol of "^o
 
-let z3_string_of_string str = 
+let z3_string_of_string str =
   try  (ignore(int_of_string str); str) with
     (* try test () with *)
-    | Failure e -> 
+    | Failure e ->
         try  (ignore(float_of_string str); str) with
         (* try test () with *)
-        | Failure e -> 
+        | Failure e ->
             try  ( ignore(bool_of_string str); str) with
-            | Failure e | Invalid_argument e ->  
+            | Failure e | Invalid_argument e ->
             if (str = "null") then  str else "\""^(String.sub str 1 (String.length str -2))^"\""
 
-let z3_normalize_string str = 
+let z3_normalize_string str =
   Str.global_replace (Str.regexp  "\'") "_prime" str;;
 
 let rec z3_string_of_term fm =
@@ -296,14 +461,14 @@ let rec z3_string_of_qformula fm =
     | And(p,q) -> "( and " ^ z3_string_of_qformula p ^" " ^z3_string_of_qformula q ^ " )"
     | Or(p,q) ->  "( or " ^ z3_string_of_qformula p ^" " ^z3_string_of_qformula q ^ " )"
     | Imp(p,q) ->  "( => " ^ z3_string_of_qformula p ^" " ^z3_string_of_qformula q ^ " )"
-    | Iff(p,q) ->  "( = " ^ z3_string_of_qformula p ^" " ^z3_string_of_qformula q ^ " )"  
+    | Iff(p,q) ->  "( = " ^ z3_string_of_qformula p ^" " ^z3_string_of_qformula q ^ " )"
     (* todo: need to add a type after the x *)
-    | Forall(x,p) -> 
-      let rname, pos = hd (type_of_var x p) in 
+    | Forall(x,p) ->
+      let rname, pos = hd (type_of_var x p) in
       "( forall ((" ^z3_normalize_string x^ " " ^rname ^string_of_int pos ^")) " ^ z3_string_of_qformula p ^ " )"
-    | Exists(x,p) -> let rname, pos = hd (type_of_var x p) in 
+    | Exists(x,p) -> let rname, pos = hd (type_of_var x p) in
       "( exists ((" ^z3_normalize_string x^ " " ^rname ^string_of_int pos ^")) " ^ z3_string_of_qformula p ^ " )"
-    
+
 let z3_string_of_fol_formula = z3_string_of_qformula;;
 
 (* ------------------------------------------------------------------------- *)
@@ -312,7 +477,7 @@ let z3_string_of_fol_formula = z3_string_of_qformula;;
 
 let rec extract_ex_quants fm =
   match fm with
-    Exists(x,p) -> let quants, body = extract_ex_quants p in 
+    Exists(x,p) -> let quants, body = extract_ex_quants p in
       x::quants, body
   | _ -> [],fm;;
 
@@ -320,15 +485,15 @@ let rec extract_ex_quants fm =
 (* Tranformation on formulas.                                                     *)
 (* ------------------------------------------------------------------------- *)
 
-let rec pnf_dnf fm = dnf_of_pnf (Skolem.pnf fm) 
-and dnf_of_pnf fm = 
-  match fm with 
+let rec pnf_dnf fm = dnf_of_pnf (Skolem.pnf fm)
+and dnf_of_pnf fm =
+  match fm with
     Forall(x,p) -> Forall(x, dnf_of_pnf p)
   | Exists(x,p) -> Exists(x, dnf_of_pnf p)
   | _ -> Prop.dnf fm;;
 
 (** take a FO formula and return its safe-range normal form *)
-let rec srnf fm = 
+let rec srnf fm =
   match fm with
       And(p,q) -> And(srnf p,srnf q)
     | Or(p,q) -> Or(srnf p,srnf q)
@@ -345,12 +510,12 @@ let rec srnf fm =
     | Not(Exists(x,p)) -> Not (Exists(x,srnf p))
     | _ -> fm;;
 
-let is_relation_symbol str = 
+let is_relation_symbol str =
   let idregex = Str.regexp "_*[A-Za-z][A-Za-z0-9_]*" in
     Str.string_match idregex str 0;;
 
 (** take a SRNF formula and return the set of its range-restricted variables*)
-let rec rr fm = 
+let rec rr fm =
   match fm with
     | True -> (true,[])
     | False -> (true,[])
@@ -360,115 +525,115 @@ let rec rr fm =
     | And(p,Atom(R("=",[Var x; Var y])))
     | And(Atom(R("=",[Var x; Var y])), p) -> let is_safe, rr_vars = rr p in if (intersect rr_vars [x;y]) = [] then (is_safe, rr_vars) else
      (is_safe, union rr_vars [x;y])
-    | And(p,q) -> let is_safe1, rr_vars1 = rr p in 
+    | And(p,q) -> let is_safe1, rr_vars1 = rr p in
       let is_safe2, rr_vars2 = rr q in
       (is_safe1 && is_safe2, union rr_vars1 rr_vars2)
-    | Or(p,q) -> let is_safe1, rr_vars1 = rr p in 
+    | Or(p,q) -> let is_safe1, rr_vars1 = rr p in
       let is_safe2, rr_vars2 = rr q in
       (is_safe1 && is_safe2, intersect rr_vars1 rr_vars2)
     | Not(p) -> (fst (rr p),[])
-    | Exists(x,p) -> let is_safe, rr_vars = rr p in 
+    | Exists(x,p) -> let is_safe, rr_vars = rr p in
       if mem x rr_vars then (is_safe, subtract rr_vars [x]) else (false, [])
     | _ -> (false,[]);;
 
-let is_safe_range fm = 
-  let is_safe, rr_vars = rr(srnf fm) in 
+let is_safe_range fm =
+  let is_safe, rr_vars = rr(srnf fm) in
   is_safe && (set_eq rr_vars (fv fm));;
 
-let rec to_dis_lst fm = 
+let rec to_dis_lst fm =
   match fm with
     Or(p,q) -> union (to_dis_lst p) (to_dis_lst q)
   | _ -> [fm];;
 
-let rec to_conj_lst fm = 
+let rec to_conj_lst fm =
   match fm with
     And(p,q) -> union (to_conj_lst p) (to_conj_lst q)
   | _ -> [fm];;
 
-let is_of_three_cases subfm = match subfm with 
+let is_of_three_cases subfm = match subfm with
   Or(_,_) -> if is_safe_range subfm then false else true
-  | Exists(_, _) -> 
-    let quants, xi = extract_ex_quants subfm in 
+  | Exists(_, _) ->
+    let quants, xi = extract_ex_quants subfm in
     if is_safe_range xi then false else true
-  | Not(Exists(x, fm)) ->   
-    let quants, xi = extract_ex_quants (Exists(x, fm)) in 
+  | Not(Exists(x, fm)) ->
+    let quants, xi = extract_ex_quants (Exists(x, fm)) in
     if is_safe_range xi then false else true
   | _ -> false;;
 
 (** apply three push-into procedures on a SRNF formula *)
-let rec push_into_subfm conj subfm = 
+let rec push_into_subfm conj subfm =
   match subfm with
   (* Push-into-or *)
-    Or(_,_) -> 
-      let powerset = allnonemptysubsets conj in 
-      let is_right_candiate cand = 
+    Or(_,_) ->
+      let powerset = allnonemptysubsets conj in
+      let is_right_candiate cand =
         let psi = Prop.list_conj cand in
-        let xi' = Prop.list_disj (List.map (fun x ->  And(psi, x)) (to_dis_lst subfm)) in 
-        is_safe_range xi' in 
+        let xi' = Prop.list_disj (List.map (fun x ->  And(psi, x)) (to_dis_lst subfm)) in
+        is_safe_range xi' in
       let right_candidates = List.filter is_right_candiate powerset in
       let sorted_candiates = Lib.sort (fun a b -> List.length a < List.length b) right_candidates in
-      let final_cand = List.hd sorted_candiates in 
-      let remain = subtract conj final_cand in 
+      let final_cand = List.hd sorted_candiates in
+      let remain = subtract conj final_cand in
       let phi_remain = Prop.list_conj remain in
       let psi = Prop.list_conj final_cand in
-      let xi' = Prop.list_disj (List.map (fun x ->  And(psi, x)) (to_dis_lst subfm)) in 
+      let xi' = Prop.list_disj (List.map (fun x ->  And(psi, x)) (to_dis_lst subfm)) in
       And(phi_remain, xi')
 
   (* Push-into-quantifier *)
   | Exists(_, _) ->
-    let powerset = allnonemptysubsets conj in 
-    let is_right_candiate cand = 
+    let powerset = allnonemptysubsets conj in
+    let is_right_candiate cand =
       let psi = Prop.list_conj cand in
       let quants, xi = extract_ex_quants subfm in
       let quants' = List.map (fun x -> variant x (fv psi)) quants in
       let subfn = fpf quants (List.map (fun x -> Fol.Var x) quants') in
-      let xi' = ( And(psi, subst subfn xi)) in 
-      is_safe_range xi' in 
+      let xi' = ( And(psi, subst subfn xi)) in
+      is_safe_range xi' in
     let right_candidates = List.filter is_right_candiate powerset in
     let sorted_candiates = Lib.sort (fun a b -> List.length a < List.length b) right_candidates in
-    let final_cand = List.hd sorted_candiates in 
-    let remain = subtract conj final_cand in 
+    let final_cand = List.hd sorted_candiates in
+    let remain = subtract conj final_cand in
     let phi_remain = Prop.list_conj remain in
     let psi = Prop.list_conj final_cand in
     let quants, xi = extract_ex_quants subfm in
     let quants' = List.map (fun x -> variant x (fv psi)) quants in
     let subfn = fpf quants (List.map (fun x -> Fol.Var x) quants') in
-    let xi' = And(psi, subst subfn xi) in 
+    let xi' = And(psi, subst subfn xi) in
     And(phi_remain, itlist mk_exists quants' xi')
   (* Push-into-negated-quantifier *)
   | Not(Exists(x, fm)) ->
-    let powerset = allnonemptysubsets conj in 
-    let is_right_candiate cand = 
+    let powerset = allnonemptysubsets conj in
+    let is_right_candiate cand =
       let psi = Prop.list_conj cand in
       let quants, xi = extract_ex_quants (Exists(x, fm)) in
       let quants' = List.map (fun x -> variant x (fv psi)) quants in
       let subfn = fpf quants (List.map (fun x -> Fol.Var x) quants') in
-      let xi' = ( And(psi, subst subfn xi)) in 
-      is_safe_range xi' in 
+      let xi' = ( And(psi, subst subfn xi)) in
+      is_safe_range xi' in
     let right_candidates = List.filter is_right_candiate powerset in
     let sorted_candiates = Lib.sort (fun a b -> List.length a < List.length b) right_candidates in
-    let final_cand = List.hd sorted_candiates in 
+    let final_cand = List.hd sorted_candiates in
     let phi = Prop.list_conj conj in
     let psi = Prop.list_conj final_cand in
     let quants, xi = extract_ex_quants (Exists(x, fm)) in
     let quants' = List.map (fun x -> variant x (fv psi)) quants in
     let subfn = fpf quants (List.map (fun x -> Fol.Var x) quants') in
-    let xi' = And(psi, subst subfn xi) in 
+    let xi' = And(psi, subst subfn xi) in
     And(phi, Not (itlist mk_exists quants' xi'))
       (* And(Prop.list_conj conj, Not(push_into_subfm conj (Exists(x, fm)))) *)
   | _ -> And(Prop.list_conj conj, subfm)
   ;;
 
 (** take a SRNF formula and return it in RANF  *)
-let rec srnf2ranf fm = 
+let rec srnf2ranf fm =
   match fm with
-    And(_,_) -> let conj_lst = to_conj_lst fm in 
+    And(_,_) -> let conj_lst = to_conj_lst fm in
         let not_self_contained_lst = List.filter is_of_three_cases conj_lst in
-        if (List.length not_self_contained_lst > 0) then 
+        if (List.length not_self_contained_lst > 0) then
           let h = List.hd not_self_contained_lst in
             srnf2ranf (push_into_subfm (subtract conj_lst [h]) h)
-        else Prop.list_conj (List.map srnf2ranf conj_lst) 
-    | Or(p, q) -> Or(srnf2ranf p, srnf2ranf q) 
+        else Prop.list_conj (List.map srnf2ranf conj_lst)
+    | Or(p, q) -> Or(srnf2ranf p, srnf2ranf q)
     | Exists(x, p) ->  Exists(x, srnf2ranf p)
     | Not(Exists(x, p)) -> Not (Exists(x, srnf2ranf p))
     | _ -> fm;;
@@ -477,7 +642,7 @@ let ranf fm = if (is_safe_range fm) then srnf2ranf (srnf fm) else failwith "the 
 
 (** take a FO formula in nnf and return its dnf *)
 (* todo: this function can not go to the lower level of quantifier *)
-let rec pure_dnf fm = 
+let rec pure_dnf fm =
   match fm with
     Forall(x,p) -> Forall(x,pure_dnf p)
   | Exists(x,p) -> Exists(x,pure_dnf p)
@@ -487,14 +652,14 @@ let rec pure_dnf fm =
 let dnf fm = pure_dnf (Skolem.nnf(Skolem.simplify fm));;
 
 (* note that in order to preserve certain order and also show the conciseness of the implementation, no tail-recursive is used *)
-let ins_all_positions x l =  
+let ins_all_positions x l =
   let rec aux prev acc = function
     | [] -> (prev @ [x]) :: acc |> List.rev
     | hd::tl as l -> aux (prev @ [hd]) ((prev @ [x] @ l) :: acc) tl
   in
   aux [] [] l
 
-let rec permutations = function  
+let rec permutations = function
   | [] -> []
   | x::[] -> [[x]] (* we must specify this edge case *)
   | x::xs -> List.fold_left (fun acc p -> acc @ ins_all_positions x p ) [] (permutations xs)
@@ -515,13 +680,13 @@ let disj_trivial lits =
 
 let remove_trivial1 fm =
   match fm with
-   And(p,q) -> 
-    let conj = (to_conj_lst fm) in  
+   And(p,q) ->
+    let conj = (to_conj_lst fm) in
     (* print_endline "checking conj :"; *)
     (* List.iter (fun x -> print_endline (lean_string_of_fol_formula x)) conj; *)
     if (conj_trivial conj) then False else simplify (list_conj conj)
-  | Or(p,q) -> 
-    let disj = (to_dis_lst fm) in 
+  | Or(p,q) ->
+    let disj = (to_dis_lst fm) in
     if (disj_trivial disj) then True else simplify (list_disj disj)
   | _ -> simplify fm;;
 
@@ -537,7 +702,7 @@ let rec remove_trivial fm =
   | _ -> fm;;
 
 (** take a FOL formula and return whether it contains view predicate or not  *)
-let rec is_superformula_of_view view fm = match fm with 
+let rec is_superformula_of_view view fm = match fm with
     False -> false
   | True -> false
   | Atom(R(r,args)) -> if r = view then true else false
@@ -549,7 +714,7 @@ let rec is_superformula_of_view view fm = match fm with
   | Forall(x,p) -> is_superformula_of_view view p
   | Exists(x,p) -> is_superformula_of_view view p
 
-(** take a RANF formula and view name to return the it in view-predicate normal form 
+(** take a RANF formula and view name to return the it in view-predicate normal form
 view-predicate normal form is represented in the form:
 (phi, a list of (a list of quantifier vars, a fol of (¬)V(vi1)∧...∧(¬)V(vimi), phi_i ) )
 *)
@@ -557,25 +722,25 @@ view-predicate normal form is represented in the form:
 let rec ranf2lvnf view fm = if not (is_superformula_of_view view fm) then (fm, []) else
     match fm with
         | Atom(R(r,lst)) -> if r = view then (False, [([],fm, True)]) else (fm, [])
-        | Or(p, q) -> 
-            let phi1, lst1 = ranf2lvnf view p in 
-            let phi2, lst2 = ranf2lvnf view q in 
-            (remove_trivial(Or(phi1, phi2)), lst1@lst2)
-        | Exists(x, p) ->  
-            let phi1, lst1 = ranf2lvnf view p in 
-            let add_exist var (varlst, vfol, phi_i) = 
-                if List.mem var varlst then (varlst, vfol, phi_i) 
-                else if List.mem var (fv vfol) then (union [var] varlst, vfol, phi_i) 
-                else (varlst, vfol, remove_trivial (mk_exists var phi_i)) in
-            let newlst = List.map (add_exist x) lst1 in 
-            (remove_trivial (mk_exists x phi1), newlst)
-        | And(_,_) -> let conj_lst = to_conj_lst fm in 
-            lvnf_of_conj (List.map (ranf2lvnf view) conj_lst)
-        | Not(p) -> 
+        | Or(p, q) ->
             let phi1, lst1 = ranf2lvnf view p in
-            let negate_e (varlst, vfol, phi_i) = 
+            let phi2, lst2 = ranf2lvnf view q in
+            (remove_trivial(Or(phi1, phi2)), lst1@lst2)
+        | Exists(x, p) ->
+            let phi1, lst1 = ranf2lvnf view p in
+            let add_exist var (varlst, vfol, phi_i) =
+                if List.mem var varlst then (varlst, vfol, phi_i)
+                else if List.mem var (fv vfol) then (union [var] varlst, vfol, phi_i)
+                else (varlst, vfol, remove_trivial (mk_exists var phi_i)) in
+            let newlst = List.map (add_exist x) lst1 in
+            (remove_trivial (mk_exists x phi1), newlst)
+        | And(_,_) -> let conj_lst = to_conj_lst fm in
+            lvnf_of_conj (List.map (ranf2lvnf view) conj_lst)
+        | Not(p) ->
+            let phi1, lst1 = ranf2lvnf view p in
+            let negate_e (varlst, vfol, phi_i) =
                 (* negate_e return a fol in linear-view normal form *)
-                if (List.length varlst) = 0 then 
+                if (List.length varlst) = 0 then
                 (* no quantifiers  *)
                 let dis_lst_of_v = disjuncts (nnf (Formulas.Not(vfol))) in
                 let lstfol = List.map (fun x -> ([],x,True)) dis_lst_of_v in
@@ -587,47 +752,47 @@ let rec ranf2lvnf view fm = if not (is_superformula_of_view view fm) then (fm, [
                 the we can pull it out
                 *)
                 else (remove_trivial(Formulas.Not(itlist mk_exists varlst ((Formulas.And (vfol, phi_i))))), [] ) in
-            let conjlst = List.map negate_e lst1 in 
+            let conjlst = List.map negate_e lst1 in
             lvnf_of_conj ((remove_trivial(Formulas.Not(phi1)), [])::conjlst)
-        
+
         | _ -> (fm, [])
 
-and and_of_two_lvnf (phi1, lst1) (phi2, lst2) = 
-    let newlst1 = ([],True,phi1)::lst1 in 
-    let newlst2 = ([],True,phi2)::lst2 in 
-    let and_two_e (vars1, vfol1, phi_i1) (vars2, vfol2, phi_i2) = 
+and and_of_two_lvnf (phi1, lst1) (phi2, lst2) =
+    let newlst1 = ([],True,phi1)::lst1 in
+    let newlst2 = ([],True,phi2)::lst2 in
+    let and_two_e (vars1, vfol1, phi_i1) (vars2, vfol2, phi_i2) =
         (* (exists vars1, vfol1 and phi_i1) and (exists vars2, vfol2 and phi_i2) *)
-        let intro_var freevars v (newvs, subfn) = 
-            let z = variant v freevars in 
-            (newvs@[v], (v |-> Fol.Var z) subfn) in 
-        let freevars1 = subtract ((union (fv (And(vfol1, phi_i1))) (fv (And(vfol2, phi_i2))))) (union vars1 vars2) in 
-        let newvars1, subfn1 = itlist (intro_var freevars1) vars1 ([],undefined) in 
-        let newvfol1 = subst subfn1 vfol1 in 
+        let intro_var freevars v (newvs, subfn) =
+            let z = variant v freevars in
+            (newvs@[v], (v |-> Fol.Var z) subfn) in
+        let freevars1 = subtract ((union (fv (And(vfol1, phi_i1))) (fv (And(vfol2, phi_i2))))) (union vars1 vars2) in
+        let newvars1, subfn1 = itlist (intro_var freevars1) vars1 ([],undefined) in
+        let newvfol1 = subst subfn1 vfol1 in
         let newphi_i1 = subst subfn1 phi_i1 in
-        (* now we get 
+        (* now we get
         exists newvars1, (newvfol1 and newphi_i1) and (exists vars2, vfol2 and phi_i2)
-        we continue to pull the vars2 in the formula 
+        we continue to pull the vars2 in the formula
         (newvfol1 and newphi_i1) and (exists vars2, vfol2 and phi_i2)
          *)
-        let freevars2 = subtract ((union (fv (And(newvfol1, newphi_i1))) (fv (And(vfol2, phi_i2))))) vars2 in 
+        let freevars2 = subtract ((union (fv (And(newvfol1, newphi_i1))) (fv (And(vfol2, phi_i2))))) vars2 in
         let newvars2, subfn2 = itlist (intro_var freevars2) vars2 ([],undefined) in
-        let newvfol2 = subst subfn2 vfol2 in 
-        let newphi_i2 = subst subfn2 phi_i2 in 
-        (* now we get 
+        let newvfol2 = subst subfn2 vfol2 in
+        let newphi_i2 = subst subfn2 phi_i2 in
+        (* now we get
         exists newvars1, exists newvars2, (newvfol1 and newphi_i1) and (newvfol2 and newvphi_i2)
          *)
-        (newvars1@newvars2, remove_trivial (And(newvfol1, newvfol2)), remove_trivial(And(newphi_i1, newphi_i2))) in 
-    let dis_law_result = allpairs and_two_e newlst1 newlst2 in 
+        (newvars1@newvars2, remove_trivial (And(newvfol1, newvfol2)), remove_trivial(And(newphi_i1, newphi_i2))) in
+    let dis_law_result = allpairs and_two_e newlst1 newlst2 in
     (* we can find the phi in this list result which is from phi1 and phi2 *)
     let phis, others = List.partition (fun x -> match x with ([], True, _) -> true | _ -> false) dis_law_result in
     let filtered_others = List.filter (fun x -> match x with (_, _, False) -> false | _ -> true) others in
-    let flattedphis = List.map (fun (_,_,x) -> x) phis in 
+    let flattedphis = List.map (fun (_,_,x) -> x) phis in
     (Prop.list_disj flattedphis, filtered_others)
 
-and lvnf_of_conj conj_lst = 
-    match conj_lst with 
+and lvnf_of_conj conj_lst =
+    match conj_lst with
     hd::tl ->
-    List.fold_left (fun x y -> and_of_two_lvnf x y) hd tl 
+    List.fold_left (fun x y -> and_of_two_lvnf x y) hd tl
     | _ -> invalid_arg "function lvnf_of_conj called with a empty list";;
 
 let ranf2lvnf view fm = ranf2lvnf view (remove_trivial fm);;

--- a/src/logic/fol_ex.ml
+++ b/src/logic/fol_ex.ml
@@ -228,48 +228,6 @@ let stringify_lean_formula (lfm : lean_formula) : string =
   in
   aux lfm
 
-(*
-let lean_logic_character name = match name with
-    | "false" -> "false"
-    | "true" -> "true"
-    | "not" -> "¬"
-    | "and" -> "∧"
-    | "or" -> "∨"
-    | "imply" -> "→"
-    | "iff" -> "↔"
-    | "forall" -> "∀"
-    | "exists" -> "∃"
-    | "quantifer_sep" -> ","
-    | _ -> failwith "unkown symbol of "^name
-
-let lean_character_of_operator o = match o with
-  | "<>" -> "≠"
-  | ">=" -> "≥"
-  | "<=" -> "≤"
-  | "=" | "<"| ">" -> o
-  | _ -> failwith "unkown symbol of "^o
-
-let lean_stype_of_string (str : string) =
-  try  (ignore(int_of_string str); "int") with
-    (* try test () with *)
-    | Failure e ->
-        try  (ignore(float_of_string str); "rat") with
-        (* try test () with *)
-        | Failure e ->
-            try  ( ignore(bool_of_string str); "Prop") with
-            | Failure e | Invalid_argument e ->  if (str = "null") then  "int" else  "string"
-
-let lean_string_of_string (str : string) =
-  try  (ignore(int_of_string str); str) with
-    (* try test () with *)
-    | Failure e ->
-        try  (ignore(float_of_string str); str) with
-        (* try test () with *)
-        | Failure e ->
-            try  ( ignore(bool_of_string str); str) with
-            | Failure e | Invalid_argument e ->
-            if (str = "null") then  str else "\""^(String.sub str 1 (String.length str -2))^"\""
-*)
 
 let lean_formula_of_literal (str : string) : lean_formula * lean_annot =
   try
@@ -304,45 +262,7 @@ let rec lean_formula_of_term (fm : term) : lean_formula =
   | Fn ("::", [tm1; tm2])      -> LeanInfix (LeanInfixCons, iter tm1, iter tm2)
   | Fn (literal, [])           -> let (lfm, styp) = lean_formula_of_literal literal in LeanAnnot (lfm, styp)
   | Fn (f, ((_ :: _) as args)) -> LeanApp (f, List.map iter args)
-(* ORIGINAL:
-  match fm with
-    Var x -> x
-  | Fn("^",[tm1;tm2]) -> lean_string_of_infix_term true prec 24 "++" tm1 tm2
-  | Fn("/",[tm1;tm2]) -> lean_string_of_infix_term true prec 22 " /" tm1 tm2
-  | Fn("*",[tm1;tm2]) -> lean_string_of_infix_term false prec 20 " *" tm1 tm2
-  | Fn("-",[tm1;tm2]) -> lean_string_of_infix_term true prec 18 " -" tm1 tm2
-  | Fn("+",[tm1;tm2]) -> lean_string_of_infix_term false prec 16 " +" tm1 tm2
-  | Fn("::",[tm1;tm2]) -> lean_string_of_infix_term false prec 14 "::" tm1 tm2
-  | Fn(f,args) -> lean_string_of_fargs f args
-*)
 
-(*
-and lean_string_of_fargs (f : string) (args : term list) : lean_formula =
-  if args = [] then
-    "("^(lean_string_of_string f)^":"^ (lean_stype_of_string f)^")"
-  else
-    f^ ( "("^
-    lean_string_of_term 0 (hd args)^ break_line 0^
-    String.concat "" (List.map (fun t ->  ","^break_line 0^ lean_string_of_term 0 t)
-            (tl args))^
-    ")")
-
-and lean_string_of_infix_term isleft oldprec newprec sym p q =
-  if oldprec > newprec then "(" else ""^
-  lean_string_of_term (if isleft then newprec else newprec+1) p^
-   sym^
-  break_line (if String.sub sym 0 1 = " " then 1 else 0)^
-  lean_string_of_term (if isleft then newprec+1 else newprec) q^
-  (if oldprec > newprec then  ")" else "");;
-
-let lean_string_of_fargs f args =
-    f^
-    if args = [] then "" else
-    ( " "^
-    lean_string_of_term 0 (hd args)^ break_line 0^
-    String.concat "" (List.map (fun t ->  " "^break_line 0^ lean_string_of_term 0 t)
-            (tl args)))
-*)
 
 let lean_formula_of_atom (R (p, args) : fol) : lean_formula =
   let iter = lean_formula_of_term in
@@ -355,27 +275,20 @@ let lean_formula_of_atom (R (p, args) : fol) : lean_formula =
   | (">=", [tm1; tm2]) -> LeanInfix (LeanInfixGeq, iter tm1, iter tm2)
   | _                  -> LeanApp (p, List.map iter args)
 
-(* ORIGINAL:
-  if mem p ["="; "<"; "<="; ">"; ">="; "<>"] && length args = 2 then
-    lean_string_of_infix_term false 12 12 (" "^ lean_character_of_operator p) (el 0 args) (el 1 args)
-  else
-    lean_string_of_fargs p args
-*)
-
 
 let lean_formula_of_fol_formula (fm : fol formula) : lean_formula =
   let rec aux fm =
     match fm with
-    | False        -> LeanBool false
-    | True         -> LeanBool true
-    | Atom pargs   -> lean_formula_of_atom pargs
-    | Not p        -> LeanNot (aux p)
-    | And (p, q)   -> LeanInfix (LeanInfixAnd, aux p, aux q)
-    | Or (p, q)    -> LeanInfix (LeanInfixOr, aux p, aux q)
-    | Imp(p, q)    -> LeanInfix (LeanInfixImp, aux p, aux q)
-    | Iff(p, q)    -> LeanInfix (LeanInfixIff, aux p, aux q)
-    | Forall(x, p) -> LeanForall (x, aux p)
-    | Exists(x, p) -> LeanExists (x, aux p)
+    | False         -> LeanBool false
+    | True          -> LeanBool true
+    | Atom pargs    -> lean_formula_of_atom pargs
+    | Not p         -> LeanNot (aux p)
+    | And (p, q)    -> LeanInfix (LeanInfixAnd, aux p, aux q)
+    | Or (p, q)     -> LeanInfix (LeanInfixOr, aux p, aux q)
+    | Imp (p, q)    -> LeanInfix (LeanInfixImp, aux p, aux q)
+    | Iff (p, q)    -> LeanInfix (LeanInfixIff, aux p, aux q)
+    | Forall (x, p) -> LeanForall (x, aux p)
+    | Exists (x, p) -> LeanExists (x, aux p)
   in
   aux (normalize_comparison fm)
 

--- a/src/logic/fol_ex.ml
+++ b/src/logic/fol_ex.ml
@@ -161,7 +161,7 @@ type lean_formula =
   | LeanNull
   | LeanBool   of bool
   | LeanInt    of int
-  | LeanFloat  of float
+  | LeanFloat  of string (* ad-hoc *)
   | LeanString of string
   | LeanVar    of lean_variable
   | LeanNot    of lean_formula
@@ -198,7 +198,7 @@ let stringify_lean_formula (lfm : lean_formula) : string =
     | LeanBool true  -> "true"
     | LeanBool false -> "false"
     | LeanInt n      -> string_of_int n
-    | LeanFloat r    -> string_of_float r
+    | LeanFloat s    -> s
     | LeanString s   -> Printf.sprintf "\"%s\"" s
     | LeanVar x      -> x
     | LeanNot lfm0   -> Printf.sprintf "(¬ %s)" (aux lfm0)
@@ -278,8 +278,8 @@ let lean_formula_of_literal (str : string) : lean_formula * lean_annot =
   with
   | _ ->
       try
-        let r = float_of_string str in
-        (LeanFloat r, LeanAnnotRat)
+        let () = ignore (float_of_string str) in
+        (LeanFloat str, LeanAnnotRat)
       with
       | _ ->
           try

--- a/src/logic/fol_ex.mli
+++ b/src/logic/fol_ex.mli
@@ -11,7 +11,50 @@ val ranf : Fol.fol Formulas.formula -> Fol.fol Formulas.formula
 
 val normalize_comparison : Fol.fol Formulas.formula -> Fol.fol Formulas.formula
 
-val lean_string_of_fol_formula : Fol.fol Formulas.formula -> string
+type lean_variable = string
+
+type lean_infix_operator =
+  | LeanInfixEqual    (* = *)
+  | LeanInfixLt       (* < *)
+  | LeanInfixGt       (* > *)
+  | LeanInfixNotEqual (* ≠ *)
+  | LeanInfixLeq      (* ≤ *)
+  | LeanInfixGeq      (* ≥ *)
+  | LeanInfixAnd
+  | LeanInfixOr
+  | LeanInfixImp
+  | LeanInfixIff
+  | LeanInfixConcat   (* ++ *)
+  | LeanInfixDiv      (* / *)
+  | LeanInfixMult     (* * *)
+  | LeanInfixSubtr    (* - *)
+  | LeanInfixAdd      (* + *)
+  | LeanInfixCons     (* :: *)
+
+(* isomorphic to `Expr.stype` *)
+type lean_annot =
+  | LeanAnnotInt
+  | LeanAnnotRat
+  | LeanAnnotString
+  | LeanAnnotProp
+
+type lean_formula =
+  | LeanNull
+  | LeanBool   of bool
+  | LeanInt    of int
+  | LeanFloat  of float
+  | LeanString of string
+  | LeanVar    of lean_variable
+  | LeanNot    of lean_formula
+  | LeanInfix  of lean_infix_operator * lean_formula * lean_formula
+  | LeanApp    of string * lean_formula list
+  | LeanForall of lean_variable * lean_formula
+  | LeanExists of lean_variable * lean_formula
+  | LeanAnnot  of lean_formula * lean_annot
+
+val stringify_lean_formula : lean_formula -> string
+
+val lean_formula_of_fol_formula : Fol.fol Formulas.formula -> lean_formula
 
 val remove_trivial : Fol.fol Formulas.formula -> Fol.fol Formulas.formula
 

--- a/src/logic/fol_ex.mli
+++ b/src/logic/fol_ex.mli
@@ -11,46 +11,7 @@ val ranf : Fol.fol Formulas.formula -> Fol.fol Formulas.formula
 
 val normalize_comparison : Fol.fol Formulas.formula -> Fol.fol Formulas.formula
 
-type lean_variable = string
-
-type lean_infix_operator =
-  | LeanInfixEqual    (* = *)
-  | LeanInfixLt       (* < *)
-  | LeanInfixGt       (* > *)
-  | LeanInfixNotEqual (* ≠ *)
-  | LeanInfixLeq      (* ≤ *)
-  | LeanInfixGeq      (* ≥ *)
-  | LeanInfixAnd
-  | LeanInfixOr
-  | LeanInfixImp
-  | LeanInfixIff
-  | LeanInfixConcat   (* ++ *)
-  | LeanInfixDiv      (* / *)
-  | LeanInfixMult     (* * *)
-  | LeanInfixSubtr    (* - *)
-  | LeanInfixAdd      (* + *)
-  | LeanInfixCons     (* :: *)
-
-(* isomorphic to `Expr.stype` *)
-type lean_annot =
-  | LeanAnnotInt
-  | LeanAnnotRat
-  | LeanAnnotString
-  | LeanAnnotProp
-
-type lean_formula =
-  | LeanNull
-  | LeanBool   of bool
-  | LeanInt    of int
-  | LeanFloat  of float
-  | LeanString of string
-  | LeanVar    of lean_variable
-  | LeanNot    of lean_formula
-  | LeanInfix  of lean_infix_operator * lean_formula * lean_formula
-  | LeanApp    of string * lean_formula list
-  | LeanForall of lean_variable * lean_formula
-  | LeanExists of lean_variable * lean_formula
-  | LeanAnnot  of lean_formula * lean_annot
+type lean_formula
 
 val stringify_lean_formula : lean_formula -> string
 


### PR DESCRIPTION
This PR refactors how to generate Lean code by adding the following intermediate datatypes for representing Lean formulae and types:

- `Ast2theorem.lean_type`
- `Ast2theorem.lean_theorem`
- `Fol_ex.lean_formula`
- `Fol_ex.lean_infix_operator`
- etc.

Similar to one former PR, the operation check for this PR has been performed by the following steps:

1. Run `benchmarks/benchmark.sh`.
2. Compare the resulting log files `benchmarks/results/compile/*/*.{log,err}` to the equivalent ones produced by `master`’s `birds`.

As a result, it has been confirmed that the produced log files were exactly the same as `master`’s ones.

Although the program seems to need more refactoring, I keep this PR minimal and containing a few essential changes (except for removing trailing spaces; this has been done automatically by the text editor I use).

I would appreciate any comments or suggestions.